### PR TITLE
Use Butterfly Kids font for SVG graphics

### DIFF
--- a/assets/fiddle-leaf-fig.svg
+++ b/assets/fiddle-leaf-fig.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
   <rect width="400" height="300" fill="#e6f7ff"/>
-  <text x="200" y="150" font-size="32" text-anchor="middle" fill="#00507a">Fiddle Leaf Fig</text>
+  <text font-family="Butterfly Kids" x="200" y="150" font-size="32" text-anchor="middle" fill="#00507a">Fiddle Leaf Fig</text>
 </svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
   <rect width="200" height="200" fill="#ffffff"/>
   <circle cx="100" cy="70" r="40" fill="#28a745"/>
-  <text x="100" y="150" font-size="24" text-anchor="middle" fill="#333">FloraGatos</text>
+  <text font-family="Butterfly Kids" x="100" y="150" font-size="24" text-anchor="middle" fill="#333">FloraGatos</text>
 </svg>

--- a/assets/snake-plant.svg
+++ b/assets/snake-plant.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
   <rect width="400" height="300" fill="#fff5e6"/>
-  <text x="200" y="150" font-size="32" text-anchor="middle" fill="#8b4513">Snake Plant</text>
+  <text font-family="Butterfly Kids" x="200" y="150" font-size="32" text-anchor="middle" fill="#8b4513">Snake Plant</text>
 </svg>

--- a/assets/succulent-trio.svg
+++ b/assets/succulent-trio.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
   <rect width="400" height="300" fill="#e0ffe0"/>
-  <text x="200" y="150" font-size="32" text-anchor="middle" fill="#006400">Succulent Trio</text>
+  <text font-family="Butterfly Kids" x="200" y="150" font-size="32" text-anchor="middle" fill="#006400">Succulent Trio</text>
 </svg>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
   <meta name="twitter:image" content="assets/logo.svg">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Butterfly+Kids&display=swap" rel="stylesheet">
   <link href="css/style.css" rel="stylesheet">
   <script type="application/ld+json">
   {


### PR DESCRIPTION
## Summary
- Apply Butterfly Kids font to logo and featured plant SVG files
- Load the Butterfly Kids font from Google Fonts in index.html

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b705ffe6a083308c2ef00c31369162