### PR TITLE
Embed Butterfly font and redesign logo

### DIFF
--- a/assets/fiddle-leaf-fig.svg
+++ b/assets/fiddle-leaf-fig.svg
@@ -1,4 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Butterfly+Kids&display=swap');
+    text { font-family: 'Butterfly Kids', cursive; }
+  </style>
   <rect width="400" height="300" fill="#e6f7ff"/>
-  <text font-family="Butterfly Kids" x="200" y="150" font-size="32" text-anchor="middle" fill="#00507a">Fiddle Leaf Fig</text>
+  <text x="200" y="150" font-size="32" text-anchor="middle" fill="#00507a">Fiddle Leaf Fig</text>
 </svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,5 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Butterfly+Kids&display=swap');
+    text { font-family: 'Butterfly Kids', cursive; }
+  </style>
   <rect width="200" height="200" fill="#ffffff"/>
-  <circle cx="100" cy="70" r="40" fill="#28a745"/>
-  <text font-family="Butterfly Kids" x="100" y="150" font-size="24" text-anchor="middle" fill="#333">FloraGatos</text>
+  <g transform="translate(60 40) scale(5)">
+    <path fill="#28a745" d="M8 6a3 3 0 1 0 0 6 3 3 0 0 0 0-6zm0 1a2 2 0 1 1 0 4 2 2 0 0 1 0-4z"/>
+    <path fill="#28a745" d="M8 0a2 2 0 0 0-2 2v2a2 2 0 1 0 4 0V2a2 2 0 0 0-2-2zm5.657 2.343a2 2 0 0 0-2.828 0l-1.414 1.414a2 2 0 1 0 2.828 2.828l1.414-1.414a2 2 0 0 0 0-2.828zM16 8a2 2 0 0 0-2-2h-2a2 2 0 1 0 0 4h2a2 2 0 0 0 2-2zm-2.343 5.657a2 2 0 0 0 0-2.828l-1.414-1.414a2 2 0 1 0-2.828 2.828l1.414 1.414a2 2 0 0 0 2.828 0zM8 16a2 2 0 0 0 2-2v-2a2 2 0 1 0-4 0v2a2 2 0 0 0 2 2zM2.343 13.657a2 2 0 0 0 2.828 0l1.414-1.414a2 2 0 1 0-2.828-2.828l-1.414 1.414a2 2 0 0 0 0 2.828zM0 8a2 2 0 0 0 2 2h2a2 2 0 1 0 0-4H2a2 2 0 0 0-2 2zm2.343-5.657a2 2 0 0 0 0 2.828l1.414 1.414a2 2 0 1 0 2.828-2.828L5.171 2.343a2 2 0 0 0-2.828 0z"/>
+  </g>
+  <text x="100" y="170" font-size="24" text-anchor="middle" fill="#333">FloraGatos</text>
 </svg>

--- a/assets/snake-plant.svg
+++ b/assets/snake-plant.svg
@@ -1,4 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Butterfly+Kids&display=swap');
+    text { font-family: 'Butterfly Kids', cursive; }
+  </style>
   <rect width="400" height="300" fill="#fff5e6"/>
-  <text font-family="Butterfly Kids" x="200" y="150" font-size="32" text-anchor="middle" fill="#8b4513">Snake Plant</text>
+  <text x="200" y="150" font-size="32" text-anchor="middle" fill="#8b4513">Snake Plant</text>
 </svg>

--- a/assets/succulent-trio.svg
+++ b/assets/succulent-trio.svg
@@ -1,4 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Butterfly+Kids&display=swap');
+    text { font-family: 'Butterfly Kids', cursive; }
+  </style>
   <rect width="400" height="300" fill="#e0ffe0"/>
-  <text font-family="Butterfly Kids" x="200" y="150" font-size="32" text-anchor="middle" fill="#006400">Succulent Trio</text>
+  <text x="200" y="150" font-size="32" text-anchor="middle" fill="#006400">Succulent Trio</text>
 </svg>


### PR DESCRIPTION
## Summary
- embed Butterfly Kids font directly in SVG plant illustrations so they display correctly
- redesign logo using Bootstrap's flower icon with Butterfly Kids typography

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b707f7f6048330a69db4209591756c