### PR TITLE
Escape ampersands in SVG font imports

### DIFF
--- a/assets/fiddle-leaf-fig.svg
+++ b/assets/fiddle-leaf-fig.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Butterfly+Kids&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Butterfly+Kids&amp;display=swap');
     text { font-family: 'Butterfly Kids', cursive; }
   </style>
   <rect width="400" height="300" fill="#e6f7ff"/>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Butterfly+Kids&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Butterfly+Kids&amp;display=swap');
     text { font-family: 'Butterfly Kids', cursive; }
   </style>
   <rect width="200" height="200" fill="#ffffff"/>

--- a/assets/snake-plant.svg
+++ b/assets/snake-plant.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Butterfly+Kids&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Butterfly+Kids&amp;display=swap');
     text { font-family: 'Butterfly Kids', cursive; }
   </style>
   <rect width="400" height="300" fill="#fff5e6"/>

--- a/assets/succulent-trio.svg
+++ b/assets/succulent-trio.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Butterfly+Kids&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Butterfly+Kids&amp;display=swap');
     text { font-family: 'Butterfly Kids', cursive; }
   </style>
   <rect width="400" height="300" fill="#e0ffe0"/>


### PR DESCRIPTION
## Summary
- fix invalid XML in SVG assets by escaping Google Fonts `&` query parameter
- ensure all SVG files render properly in browsers

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET, glob
for f in glob.glob('assets/*.svg'):
    ET.parse(f)
    print(f, 'OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b709c993048330bc3749a5b09c9113