### PR TITLE
Add hero section with terrarium image

### DIFF
--- a/assets/hero-terrarium.svg
+++ b/assets/hero-terrarium.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#f5f5f5"/>
+  <g stroke="#888" stroke-width="4" fill="none">
+    <ellipse cx="256" cy="240" rx="150" ry="190" fill="#ffffff"/>
+    <rect x="176" y="60" width="160" height="40" fill="#e0e0e0"/>
+    <line x1="176" y1="100" x2="336" y2="100"/>
+  </g>
+  <g fill="#5cb85c">
+    <path d="M256 320c-60-80-60-80-120 0 60-120 180-120 240 0-60-80-60-80-120 0z"/>
+    <ellipse cx="236" cy="240" rx="20" ry="30"/>
+    <ellipse cx="276" cy="260" rx="20" ry="40"/>
+  </g>
+</svg>

--- a/css/style.css
+++ b/css/style.css
@@ -6,3 +6,11 @@ body {
 section {
   margin-bottom: 2rem;
 }
+.hero {
+  background-color: #f8f9fa;
+}
+
+.hero-image {
+  max-width: 100%;
+  height: auto;
+}

--- a/js/components/home/home.template.html
+++ b/js/components/home/home.template.html
@@ -1,3 +1,13 @@
+<section class="hero py-5 bg-light">
+  <div class="container d-flex flex-column flex-md-row align-items-center">
+    <div class="text-center text-md-start">
+      <h1 class="display-5 fw-bold mb-3">FloraGatos – Low-Maintenance Terrariums for Busy Lifestyles.</h1>
+      <p class="lead mb-0">Bring nature indoors with beautiful, self-sustaining ecosystems. Perfect for home, office, or as thoughtful gifts.</p>
+    </div>
+    <img src="assets/hero-terrarium.svg" alt="Terrarium jar" class="img-fluid hero-image mt-4 mt-md-0 ms-md-4" />
+  </div>
+</section>
+
 <section class="text-center py-5">
   <h1 class="display-4 mb-3">Bring Home the Beauty of Plants</h1>
   <p class="lead mb-4">


### PR DESCRIPTION
## Summary
- introduce hero section highlighting terrariums on home page
- style hero and include terrarium illustration asset

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b71afd9a508330926ec61f971b83bc