### PR TITLE
Improve hero section image layout

### DIFF
--- a/assets/hero-terrarium.svg
+++ b/assets/hero-terrarium.svg
@@ -1,13 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <rect width="512" height="512" fill="#f5f5f5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="#f5f5f5"/>
   <g stroke="#888" stroke-width="4" fill="none">
-    <ellipse cx="256" cy="240" rx="150" ry="190" fill="#ffffff"/>
-    <rect x="176" y="60" width="160" height="40" fill="#e0e0e0"/>
-    <line x1="176" y1="100" x2="336" y2="100"/>
+    <ellipse cx="200" cy="160" rx="120" ry="150" fill="#ffffff"/>
+    <rect x="120" y="40" width="160" height="40" fill="#e0e0e0"/>
+    <line x1="120" y1="80" x2="280" y2="80"/>
   </g>
   <g fill="#5cb85c">
-    <path d="M256 320c-60-80-60-80-120 0 60-120 180-120 240 0-60-80-60-80-120 0z"/>
-    <ellipse cx="236" cy="240" rx="20" ry="30"/>
-    <ellipse cx="276" cy="260" rx="20" ry="40"/>
+    <path d="M200 220c-50-70-50-70-100 0 50-105 150-105 200 0-50-70-50-70-100 0z"/>
+    <ellipse cx="185" cy="160" rx="15" ry="25"/>
+    <ellipse cx="215" cy="180" rx="15" ry="35"/>
   </g>
 </svg>

--- a/css/style.css
+++ b/css/style.css
@@ -11,6 +11,7 @@ section {
 }
 
 .hero-image {
-  max-width: 100%;
+  max-width: 320px;
+  width: 100%;
   height: auto;
 }

--- a/js/components/home/home.template.html
+++ b/js/components/home/home.template.html
@@ -1,10 +1,14 @@
 <section class="hero py-5 bg-light">
-  <div class="container d-flex flex-column flex-md-row align-items-center">
-    <div class="text-center text-md-start">
-      <h1 class="display-5 fw-bold mb-3">FloraGatos – Low-Maintenance Terrariums for Busy Lifestyles.</h1>
-      <p class="lead mb-0">Bring nature indoors with beautiful, self-sustaining ecosystems. Perfect for home, office, or as thoughtful gifts.</p>
+  <div class="container">
+    <div class="row align-items-center justify-content-center">
+      <div class="col-md-6 text-center text-md-start">
+        <h1 class="display-5 fw-bold mb-3">FloraGatos – Low-Maintenance Terrariums for Busy Lifestyles.</h1>
+        <p class="lead mb-0">Bring nature indoors with beautiful, self-sustaining ecosystems. Perfect for home, office, or as thoughtful gifts.</p>
+      </div>
+      <div class="col-md-6 text-center mt-4 mt-md-0">
+        <img src="assets/hero-terrarium.svg" alt="Terrarium jar" class="hero-image img-fluid" />
+      </div>
     </div>
-    <img src="assets/hero-terrarium.svg" alt="Terrarium jar" class="img-fluid hero-image mt-4 mt-md-0 ms-md-4" />
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- restructure hero section markup using Bootstrap grid for proper centering
- constrain hero image size with new styles and replace terrarium illustration

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b71da924788330ba8df48dbff03ef8