### PR TITLE
Add terrarium product listing page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -50,3 +50,9 @@ section {
   border-radius: 0.5rem;
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.1);
 }
+
+.terrarium-page {
+  border: 1px solid #dee2e6;
+  border-radius: 0.5rem;
+  padding: 1rem;
+}

--- a/index.html
+++ b/index.html
@@ -87,15 +87,10 @@
         <nav class="collapse navbar-collapse" id="navbarNav" role="navigation">
           <ul class="navbar-nav ms-auto">
             <li class="nav-item"><a class="nav-link" href="#/">Home</a></li>
-            <li class="nav-item">
-              <a class="nav-link" href="#/shop">Shop</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="#/about">About</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="#/contact">Contact</a>
-            </li>
+            <li class="nav-item"><a class="nav-link" href="#/shop">Shop</a></li>
+            <li class="nav-item"><a class="nav-link" href="#/terrariums">Terrariums</a></li>
+            <li class="nav-item"><a class="nav-link" href="#/about">About</a></li>
+            <li class="nav-item"><a class="nav-link" href="#/contact">Contact</a></li>
           </ul>
         </nav>
       </div>
@@ -132,6 +127,7 @@
     <script src="js/components/home/home.component.js"></script>
     <script src="js/components/shop/shop.component.js"></script>
     <script src="js/components/about/about.component.js"></script>
+    <script src="js/components/terrariums/terrariums.component.js"></script>
     <script src="js/components/contact/contact.component.js"></script>
   </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -16,6 +16,10 @@
         template: '<shop></shop>',
         title: 'Shop | FloraGatos'
       })
+      .when('/terrariums', {
+        template: '<terrariums></terrariums>',
+        title: 'Terrariums | FloraGatos'
+      })
       .when('/about', {
         template: '<about></about>',
         title: 'About | FloraGatos'

--- a/js/components/terrariums/terrariums.component.js
+++ b/js/components/terrariums/terrariums.component.js
@@ -1,0 +1,35 @@
+(function () {
+  'use strict';
+
+  angular.module('floraGatos').component('terrariums', {
+    templateUrl: 'js/components/terrariums/terrariums.template.html',
+    controller: TerrariumsController,
+  });
+
+  function TerrariumsController() {
+    var vm = this;
+
+    vm.products = [
+      {
+        name: 'Woodland Moss Terrarium',
+        image: 'assets/terrarium_on_desk.png',
+        description: 'Compact glass terrarium filled with lush green mosses.',
+        details:
+          'This handcrafted terrarium brings a slice of the forest floor to your desk. Features layered drainage, nutrient-rich substrate, and a mix of thriving moss varieties.',
+      },
+      {
+        name: 'Desert Cactus Terrarium',
+        image: 'https://via.placeholder.com/300x200?text=Terrarium',
+        description: 'A sun-loving mini desert landscape in a clear dome.',
+        details:
+          'A striking arrangement of miniature cacti and stones that thrives on minimal water. Perfect for bright spaces and busy plant lovers.',
+      },
+    ];
+
+    vm.selectedProduct = {};
+
+    vm.openDetails = function (product) {
+      vm.selectedProduct = product;
+    };
+  }
+})();

--- a/js/components/terrariums/terrariums.template.html
+++ b/js/components/terrariums/terrariums.template.html
@@ -1,0 +1,86 @@
+<section class="terrarium-page mt-4">
+  <h1 class="h3 mb-3">Terrariums</h1>
+  <p>
+    Terrariums are miniature ecosystems enclosed in glass, offering a captivating way to showcase plants while requiring minimal care. Their self-sustaining nature makes them perfect for desks, shelves, or any small space craving a touch of greenery.
+  </p>
+  <div class="text-center my-4">
+    <img
+      src="assets/terrarium_layers.png"
+      alt="Diagram of terrarium layers"
+      class="img-fluid rounded"
+    />
+    <ul class="text-start mt-3">
+      <li><strong>LECA Balls –</strong> Expanded clay pebbles that provide drainage.</li>
+      <li><strong>Mesh –</strong> Prevents soil from mixing with the drainage layer.</li>
+      <li><strong>Charcoal –</strong> Filters impurities and keeps the terrarium fresh.</li>
+      <li><strong>Substrate –</strong> A mix of orchid bark, worm castings, horticultural charcoal, and sphagnum moss, creating a rich growing medium.</li>
+      <li><strong>Plants –</strong> The final layer where your chosen greenery thrives.</li>
+    </ul>
+  </div>
+
+  <div class="row">
+    <div class="col-md-4 mb-4" ng-repeat="product in $ctrl.products">
+      <div class="card h-100">
+        <img
+          ng-src="{{product.image}}"
+          alt="{{product.name}}"
+          class="card-img-top"
+        />
+        <div class="card-body d-flex flex-column">
+          <h2 class="h5 card-title">{{product.name}}</h2>
+          <p class="card-text">{{product.description}}</p>
+          <button
+            class="btn btn-success mt-auto"
+            data-bs-toggle="modal"
+            data-bs-target="#productModal"
+            ng-click="$ctrl.openDetails(product)"
+          >
+            Details
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div
+  class="modal fade"
+  id="productModal"
+  tabindex="-1"
+  aria-labelledby="productModalLabel"
+  aria-hidden="true"
+>
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="productModalLabel">
+          {{$ctrl.selectedProduct.name}}
+        </h5>
+        <button
+          type="button"
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="Close"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <img
+          ng-src="{{$ctrl.selectedProduct.image}}"
+          alt="{{$ctrl.selectedProduct.name}}"
+          class="img-fluid mb-3"
+        />
+        <p>{{$ctrl.selectedProduct.details}}</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-success">Buy</button>
+        <button
+          type="button"
+          class="btn btn-secondary"
+          data-bs-dismiss="modal"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Introduce a dedicated Terrariums page with descriptive content and product cards.
- Add modal-driven product details with placeholder images and a Buy button.
- Wire up new route, navigation link, and subtle border styling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b758df7f78833092fe7d89ac29af6c