### PR TITLE
Fix top navigation links in AngularJS app

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6,7 +6,9 @@
     .config(config)
     .controller('MainCtrl', MainCtrl);
 
-  function config($routeProvider) {
+  function config($routeProvider, $locationProvider) {
+    $locationProvider.hashPrefix('');
+
     $routeProvider
       .when('/', {
         template: '<home></home>',


### PR DESCRIPTION
## Summary
- ensure AngularJS router uses `#/` style paths by removing default hashbang prefix

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b75a917bc483308b300014b715242b