### PR TITLE
Restore product detail modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -61,3 +61,7 @@ section {
   height: 220px;
   object-fit: cover;
 }
+
+.product-card {
+  cursor: pointer;
+}

--- a/js/components/terrariums/terrariums.template.html
+++ b/js/components/terrariums/terrariums.template.html
@@ -47,7 +47,14 @@
   <h2 class="text-center mb-4">Our Products</h2>
   <div class="row row-cols-1 row-cols-md-3 g-4">
     <div class="col" ng-repeat="product in $ctrl.products">
-      <div class="card h-100 shadow-sm border-0 rounded-3 product-card">
+      <div
+        class="card h-100 shadow-sm border-0 rounded-3 product-card"
+        role="button"
+        tabindex="0"
+        ng-click="$ctrl.openDetails(product)"
+        data-bs-toggle="modal"
+        data-bs-target="#productModal"
+      >
         <img
           ng-src="{{product.image}}"
           alt="{{product.name}}"


### PR DESCRIPTION
## Summary
- Make terrarium product cards open a modal with image and details when clicked
- Add cursor pointer styling for product cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b76eb4ba9c8330875ba16ab5ca151d