### PR TITLE
Expand homepage and about page content

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,17 +7,17 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta
       name="description"
-      content="Shop local plants at FloraGatos in Los Gatos. Discover fresh indoor and outdoor plants delivered with care."
+      content="FloraGatos is a Los Gatos–based online plant shop specializing in indoor houseplants, terrariums, and succulents with local Bay Area delivery and nationwide Etsy shipping."
     />
     <meta
       name="keywords"
-      content="FloraGatos, plants, Los Gatos, indoor plants, succulent, plant shop"
+      content="FloraGatos, Los Gatos plant shop, indoor plants, terrariums, succulents, plant delivery, Bay Area, Etsy"
     />
     <link rel="canonical" href="https://floragatos.example.com/" />
     <meta property="og:title" content="FloraGatos | Plants from Los Gatos" />
     <meta
       property="og:description"
-      content="Shop local plants at FloraGatos in Los Gatos. Discover fresh indoor and outdoor plants delivered with care."
+      content="Los Gatos indoor plant shop offering terrariums, succulents, and houseplants with local delivery and nationwide Etsy shipping."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://floragatos.example.com/" />
@@ -26,7 +26,7 @@
     <meta name="twitter:title" content="FloraGatos | Plants from Los Gatos" />
     <meta
       name="twitter:description"
-      content="Shop local plants at FloraGatos in Los Gatos. Discover fresh indoor and outdoor plants delivered with care."
+      content="Los Gatos indoor plant shop offering terrariums, succulents, and houseplants with local delivery and nationwide Etsy shipping."
     />
     <meta name="twitter:image" content="assets/logo.png" />
     <link

--- a/js/components/about/about.template.html
+++ b/js/components/about/about.template.html
@@ -1,8 +1,92 @@
 <section class="border rounded-3 p-5">
-  <h1 class="mb-3">About FloraGatos</h1>
-  <p>
-    FloraGatos is a small plant shop based in Los Gatos, California. Our passion
-    for plants inspires us to share the joy of gardening with everyone. Follow
-    us for tips, rare finds, and local events.
-  </p>
+  <h1 class="mb-4 text-center butterfly-kids">About FloraGatos</h1>
+
+  <div class="text-center mb-4">
+    <img
+      src="assets/terrarium_red_fittonia_on_desk.png"
+      alt="FloraGatos terrarium on a desk"
+      class="img-fluid rounded shadow-sm"
+    />
+  </div>
+
+  <section class="mb-5">
+    <h2 class="h4">Our Story</h2>
+    <p>
+      At FloraGatos, we believe nature shouldn’t be a luxury—it should be part
+      of daily life. With today’s fast-paced lifestyle, many people lose their
+      connection to the natural world. That’s why we created FloraGatos: to make
+      it easy to enjoy the beauty and benefits of indoor plants.
+    </p>
+  </section>
+
+  <section class="mb-5">
+    <h2 class="h4">What We Offer</h2>
+    <ul class="list-unstyled">
+      <li class="mb-3">
+        <h3 class="h5">Indoor Plants</h3>
+        <p>
+          From beginner-friendly succulents to bold, leafy houseplants like
+          Monstera and pothos.
+        </p>
+      </li>
+      <li class="mb-3">
+        <h3 class="h5">Terrariums</h3>
+        <p>
+          Custom-built, glass-jar ecosystems that thrive in any office or home
+          environment. They’re low-maintenance, long-lasting, and designed to
+          bring calm to your space.
+        </p>
+      </li>
+      <li class="mb-3">
+        <h3 class="h5">Accessories</h3>
+        <p>
+          Decorative pots, soil mixes, and moss poles to support healthy plant
+          growth.
+        </p>
+      </li>
+    </ul>
+  </section>
+
+  <section class="mb-5">
+    <h2 class="h4">Delivery &amp; Shipping</h2>
+    <ul class="list-unstyled">
+      <li class="mb-3">
+        <h3 class="h5">Bay Area Delivery</h3>
+        <p>
+          Our handcrafted terrariums are too delicate for shipping, so we
+          personally deliver them across the Bay Area at a low cost.
+        </p>
+      </li>
+      <li class="mb-3">
+        <h3 class="h5">Etsy Shop</h3>
+        <p>
+          For succulents, small plants, and accessories, we ship nationwide via
+          our
+          <a
+            href="https://www.etsy.com/shop/FloraGatos"
+            target="_blank"
+            rel="noopener"
+            >Etsy store</a
+          >.
+        </p>
+      </li>
+    </ul>
+  </section>
+
+  <section class="mb-4">
+    <h2 class="h4">Why Choose FloraGatos?</h2>
+    <ul>
+      <li>Local Los Gatos roots, serving the Bay Area community.</li>
+      <li>A passion for plants and sustainable living.</li>
+      <li>
+        Personal service—whether you’re just starting your plant journey or
+        adding to your collection, we’re here to help.
+      </li>
+    </ul>
+  </section>
+
+  <div class="text-center">
+    <a class="btn btn-success btn-lg me-2" href="#/">Home</a>
+    <a class="btn btn-outline-success btn-lg" href="#/shop">Explore Plants</a>
+  </div>
 </section>

--- a/js/components/home/home.template.html
+++ b/js/components/home/home.template.html
@@ -1,28 +1,21 @@
-<section class="hero py-5 rounded-3 bg-warning bg-opacity-10">
+<section class="hero py-5 rounded-3 bg-success bg-opacity-10">
   <div class="container">
     <div class="row align-items-center justify-content-center">
       <div class="col-md-6 text-center text-md-start">
-        <h1 class="display-5 fw-bold mb-3 butterfly-kids">
-          Beautiful Plants for Every Space.
+        <h1 class="display-4 fw-bold mb-3 butterfly-kids">
+          Bring Nature Indoors with FloraGatos
         </h1>
-
         <p class="lead mb-4">
-          Discover hand-crafted greenery and stylish planters that brighten your
-          home or office.
+          FloraGatos is a Los Gatos–based online plant shop, specializing in indoor houseplants that brighten homes and workspaces.
         </p>
-        <a
-          class="btn btn-success btn-lg"
-          href="https://www.etsy.com/shop/FloraGatos"
-          target="_blank"
-          rel="noopener"
-          >Shop Now <i class="bi bi-flower2"></i
-        ></a>
+        <a class="btn btn-success btn-lg me-2" href="#/shop">Shop Now <i class="bi bi-flower2"></i></a>
+        <a class="btn btn-outline-success btn-lg" href="#/about">Learn More</a>
       </div>
       <div class="col-md-6 text-center mt-4 mt-md-0">
         <div class="hero-image-wrapper">
           <img
             src="assets/hero_plants.png"
-            alt="Office desk with a terrarium and plant"
+            alt="Indoor plants from FloraGatos"
             class="hero-image img-fluid"
           />
         </div>
@@ -31,35 +24,64 @@
   </div>
 </section>
 
-<section class="text-center py-5">
-  <h1 class="display-4 mb-3 butterfly-kids">Bring Home the Beauty of Plants</h1>
-  <p class="lead mb-4">
-    Hand-selected greenery from Los Gatos to your doorstep.
-  </p>
-  <a
-    class="btn btn-success btn-lg"
-    href="https://www.etsy.com/shop/FloraGatos"
-    target="_blank"
-    rel="noopener"
-    >Shop on Etsy <i class="bi bi-flower2"></i
-  ></a>
+<section class="py-5">
+  <div class="container">
+    <h2 class="text-center mb-5 butterfly-kids">Highlights</h2>
+    <div class="row g-4 text-center">
+      <div class="col-md-6 col-lg-3">
+        <img
+          src="assets/succulents_window.png"
+          alt="Succulents for sunny spots"
+          class="img-fluid rounded mb-3 shadow-sm"
+        />
+        <h3 class="h5">Succulents for sunny spots</h3>
+        <p class="mb-0">
+          Perfect for windowsills and spaces with direct sunlight.
+        </p>
+      </div>
+      <div class="col-md-6 col-lg-3">
+        <img
+          src="assets/terrarium_on_desk.png"
+          alt="Terrarium for every space"
+          class="img-fluid rounded mb-3 shadow-sm"
+        />
+        <h3 class="h5">Terrariums for every space</h3>
+        <p class="mb-0">
+          Low-maintenance ecosystems that thrive under LED lights, ideal for offices and cozy corners.
+        </p>
+      </div>
+      <div class="col-md-6 col-lg-3">
+        <img
+          src="assets/terrarium_layers.png"
+          alt="Care made simple"
+          class="img-fluid rounded mb-3 shadow-sm"
+        />
+        <h3 class="h5">Care made simple</h3>
+        <p class="mb-0">
+          Our terrariums barely need watering—just light and love.
+        </p>
+      </div>
+      <div class="col-md-6 col-lg-3">
+        <img
+          src="assets/terrarium_kitchen_counter.png"
+          alt="Local delivery and Etsy shop"
+          class="img-fluid rounded mb-3 shadow-sm"
+        />
+        <h3 class="h5">Local delivery + Etsy shop</h3>
+        <p class="mb-0">
+          Terrariums delivered safely across the Bay Area. Smaller plants and accessories shipped nationwide through Etsy.
+        </p>
+      </div>
+    </div>
+  </div>
 </section>
 
-<section class="row text-center mb-5">
-  <div class="col-md-4 mb-4">
-    <i class="bi bi-heart-pulse fs-1 text-success" aria-hidden="true"></i>
-    <h2 class="h5 mt-3">Healthy Plants</h2>
-    <p>Each plant is nurtured with love and care.</p>
-  </div>
-  <div class="col-md-4 mb-4">
-    <i class="bi bi-truck fs-1 text-success" aria-hidden="true"></i>
-    <h2 class="h5 mt-3">Fast Delivery</h2>
-    <p>Local pickups and quick shipping options.</p>
-  </div>
-  <div class="col-md-4 mb-4">
-    <i class="bi bi-hand-thumbs-up fs-1 text-success" aria-hidden="true"></i>
-    <h2 class="h5 mt-3">Green Thumb Help</h2>
-    <p>Count on us for answers to all your plant questions.</p>
+<section class="text-center py-5 bg-light rounded mb-5">
+  <div class="container">
+    <h2 class="display-6 mb-4 butterfly-kids">
+      Explore our collection today and discover how easy it is to bring a little greenery into your everyday life.
+    </h2>
+    <a class="btn btn-success btn-lg" href="#/shop">Explore Plants <i class="bi bi-flower2"></i></a>
   </div>
 </section>
 
@@ -143,3 +165,4 @@
     border-top-right-radius: 0.5rem;
   }
 </style>
+


### PR DESCRIPTION
## Summary
- Revamped homepage hero and highlights with new imagery, feature sections, and call-to-action linking to shop and about pages.
- Expanded about page with detailed story, offerings, delivery info, and internal links, plus added supporting imagery.
- Improved SEO metadata to emphasize Los Gatos roots, terrariums, succulents, and Etsy shipping options.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b0491abc8330bb458b87285d0e91