### PR TITLE
Standardize product pages and product modals

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -51,7 +51,7 @@ section {
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.1);
 }
 
-.terrarium-page {
+.product-page {
   padding: 1rem;
   background-color: #fff;
   border-radius: 0.5rem;

--- a/js/components/indoor/indoor.template.html
+++ b/js/components/indoor/indoor.template.html
@@ -1,14 +1,14 @@
-<section class="indoor-page py-5 border rounded-3">
+<section class="product-page indoor-page py-5 border rounded-3">
   <div class="text-center mb-5">
     <h1 class="fw-bold display-1 mb-3 butterfly-kids">Indoor House Plants</h1>
-    <p class="lead mx-auto" style="max-width: 700px">
-      Lush greenery that thrives inside your home and purifies the air.
-    </p>
     <img
       src="assets/indoor_hero.svg"
       alt="Indoor house plants"
-      class="img-fluid rounded shadow"
+      class="img-fluid rounded shadow mb-3"
     />
+    <p class="lead mx-auto" style="max-width: 700px">
+      Lush greenery that thrives inside your home and purifies the air.
+    </p>
   </div>
 
   <h2
@@ -49,7 +49,7 @@
   aria-labelledby="productModalLabel"
   aria-hidden="true"
 >
-  <div class="modal-dialog modal-dialog-centered">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
     <div class="modal-content shadow-lg border-0 rounded-4">
       <div class="modal-header bg-light">
         <h5 class="modal-title display-6 butterfly-kids" id="productModalLabel">
@@ -63,25 +63,28 @@
         ></button>
       </div>
       <div class="modal-body">
-        <img
-          ng-src="{{$ctrl.selectedProduct.image}}"
-          alt="{{$ctrl.selectedProduct.name}}"
-          class="img-fluid mb-3 rounded"
-        />
-
-        <p class="text-muted ps-1 pe-1">{{$ctrl.selectedProduct.details}}</p>
-
-        <!-- Pricing Section -->
-        <div class="mt-3">
-          <span class="fs-4 fw-semibold text-success">
-            ${{$ctrl.selectedProduct.price}}
-          </span>
+        <div class="row g-4 align-items-center">
+          <div class="col-md-6">
+            <img
+              ng-src="{{$ctrl.selectedProduct.image}}"
+              alt="{{$ctrl.selectedProduct.name}}"
+              class="img-fluid rounded"
+            />
+          </div>
+          <div class="col-md-6">
+            <p class="text-muted ps-1 pe-1 mb-3">
+              {{$ctrl.selectedProduct.details}}
+            </p>
+            <div class="fs-4 fw-semibold text-success mb-3">
+              ${{$ctrl.selectedProduct.price}}
+            </div>
+            <button type="button" class="btn btn-success btn-lg w-100">
+              <i class="bi bi-cart-plus me-2"></i> Buy
+            </button>
+          </div>
         </div>
       </div>
-      <div class="modal-footer justify-content-between">
-        <button type="button" class="btn btn-success btn-lg">
-          <i class="bi bi-cart-plus me-2"></i> Buy
-        </button>
+      <div class="modal-footer">
         <button
           type="button"
           class="btn btn-outline-secondary"

--- a/js/components/succulents/succulents.template.html
+++ b/js/components/succulents/succulents.template.html
@@ -1,14 +1,15 @@
-<section class="succulents-page py-5 border rounded-3">
+<section class="product-page succulents-page py-5 border rounded-3">
   <div class="text-center mb-5">
     <h1 class="fw-bold display-1 mb-3 butterfly-kids">Succulents</h1>
-    <p class="lead mx-auto" style="max-width: 700px">
-      Low-maintenance plants that store water in their leaves and thrive in bright light.
-    </p>
     <img
       src="assets/succulents_hero.svg"
       alt="Assorted succulents"
-      class="img-fluid rounded shadow"
+      class="img-fluid rounded shadow mb-3"
     />
+    <p class="lead mx-auto" style="max-width: 700px">
+      Low-maintenance plants that store water in their leaves and thrive in
+      bright light.
+    </p>
   </div>
 
   <h2
@@ -49,7 +50,7 @@
   aria-labelledby="productModalLabel"
   aria-hidden="true"
 >
-  <div class="modal-dialog modal-dialog-centered">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
     <div class="modal-content shadow-lg border-0 rounded-4">
       <div class="modal-header bg-light">
         <h5 class="modal-title display-6 butterfly-kids" id="productModalLabel">
@@ -63,25 +64,28 @@
         ></button>
       </div>
       <div class="modal-body">
-        <img
-          ng-src="{{$ctrl.selectedProduct.image}}"
-          alt="{{$ctrl.selectedProduct.name}}"
-          class="img-fluid mb-3 rounded"
-        />
-
-        <p class="text-muted ps-1 pe-1">{{$ctrl.selectedProduct.details}}</p>
-
-        <!-- Pricing Section -->
-        <div class="mt-3">
-          <span class="fs-4 fw-semibold text-success">
-            ${{$ctrl.selectedProduct.price}}
-          </span>
+        <div class="row g-4 align-items-center">
+          <div class="col-md-6">
+            <img
+              ng-src="{{$ctrl.selectedProduct.image}}"
+              alt="{{$ctrl.selectedProduct.name}}"
+              class="img-fluid rounded"
+            />
+          </div>
+          <div class="col-md-6">
+            <p class="text-muted ps-1 pe-1 mb-3">
+              {{$ctrl.selectedProduct.details}}
+            </p>
+            <div class="fs-4 fw-semibold text-success mb-3">
+              ${{$ctrl.selectedProduct.price}}
+            </div>
+            <button type="button" class="btn btn-success btn-lg w-100">
+              <i class="bi bi-cart-plus me-2"></i> Buy
+            </button>
+          </div>
         </div>
       </div>
-      <div class="modal-footer justify-content-between">
-        <button type="button" class="btn btn-success btn-lg">
-          <i class="bi bi-cart-plus me-2"></i> Buy
-        </button>
+      <div class="modal-footer">
         <button
           type="button"
           class="btn btn-outline-secondary"

--- a/js/components/terrariums/terrariums.template.html
+++ b/js/components/terrariums/terrariums.template.html
@@ -1,8 +1,13 @@
-<section class="terrarium-page py-5 border rounded-3">
+<section class="product-page terrarium-page py-5 border rounded-3">
   <div class="text-center mb-5">
     <h1 class="fw-bold display-1 mb-3 butterfly-kids">
       Discover the World of Terrariums
     </h1>
+    <img
+      src="assets/terrariums_for_every_space.png"
+      alt="Assorted terrariums"
+      class="img-fluid rounded shadow mb-3"
+    />
     <p class="lead mx-auto" style="max-width: 700px">
       Terrariums are miniature, self-sustaining ecosystems housed in glass
       containers. They bring a touch of nature indoors, requiring minimal
@@ -10,7 +15,7 @@
     </p>
   </div>
 
-  <div class="row align-items-center g-4 mb-4">
+  <div class="row align-items-center g-4 mb-5">
     <div class="col-md-6 text-center">
       <img
         src="assets/terrarium_layers.png"
@@ -84,7 +89,7 @@
   aria-labelledby="productModalLabel"
   aria-hidden="true"
 >
-  <div class="modal-dialog modal-dialog-centered">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
     <div class="modal-content shadow-lg border-0 rounded-4">
       <div class="modal-header bg-light">
         <h5 class="modal-title display-6 butterfly-kids" id="productModalLabel">
@@ -98,25 +103,28 @@
         ></button>
       </div>
       <div class="modal-body">
-        <img
-          ng-src="{{$ctrl.selectedProduct.image}}"
-          alt="{{$ctrl.selectedProduct.name}}"
-          class="img-fluid mb-3 rounded"
-        />
-
-        <p class="text-muted ps-1 pe-1">{{$ctrl.selectedProduct.details}}</p>
-
-        <!-- Pricing Section -->
-        <div class="mt-3">
-          <span class="fs-4 fw-semibold text-success">
-            ${{$ctrl.selectedProduct.price}}
-          </span>
+        <div class="row g-4 align-items-center">
+          <div class="col-md-6">
+            <img
+              ng-src="{{$ctrl.selectedProduct.image}}"
+              alt="{{$ctrl.selectedProduct.name}}"
+              class="img-fluid rounded"
+            />
+          </div>
+          <div class="col-md-6">
+            <p class="text-muted ps-1 pe-1 mb-3">
+              {{$ctrl.selectedProduct.details}}
+            </p>
+            <div class="fs-4 fw-semibold text-success mb-3">
+              ${{$ctrl.selectedProduct.price}}
+            </div>
+            <button type="button" class="btn btn-success btn-lg w-100">
+              <i class="bi bi-cart-plus me-2"></i> Buy
+            </button>
+          </div>
         </div>
       </div>
-      <div class="modal-footer justify-content-between">
-        <button type="button" class="btn btn-success btn-lg">
-          <i class="bi bi-cart-plus me-2"></i> Buy
-        </button>
+      <div class="modal-footer">
         <button
           type="button"
           class="btn btn-outline-secondary"


### PR DESCRIPTION
## Summary
- unify terrarium, succulent, and indoor pages with a shared layout and hero images
- add reusable `product-page` styling for consistent presentation
- redesign product detail modals to place image beside description, price, and buy button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ea45591c8330ac567b07c31253b2